### PR TITLE
Content Placeholders in Masterpage were missing

### DIFF
--- a/SharePoint 2010/GCWU - SharePoint 2010 - WET 4.1 [Beta]/SPWET4/SPWET4/Master Pages/WET4Publishing.master
+++ b/SharePoint 2010/GCWU - SharePoint 2010 - WET 4.1 [Beta]/SPWET4/SPWET4/Master Pages/WET4Publishing.master
@@ -498,7 +498,8 @@
                                         </ul>
                                     </nav>
                                 </div>
-                            </div>
+
+</div>
                         </footer>
 
                     </div>
@@ -530,6 +531,8 @@
                 <asp:ContentPlaceHolder ID="WSSDesignConsole" runat="server" />
                 <asp:ContentPlaceHolder ID="PlaceHolderMiniConsole" runat="server" />
                 <asp:ContentPlaceHolder id="PlaceHolderSearchArea" runat="server" />
+		<asp:ContentPlaceHolder id="PlaceHolderLeftActions" runat="server"/>
+                <asp:ContentPlaceHolder id="PlaceHolderPageDescription" runat="server" />
             </asp:Panel>
             <asp:ContentPlaceHolder ID="PlaceHolderFormDigest" runat="server">
                 <SharePoint:FormDigest runat="server" />


### PR DESCRIPTION
There were two content place holders missing from this MasterPage that were causing an error when displaying the majority of SharePoint pages.

These are the two that were missing:
<asp:ContentPlaceHolder id="PlaceHolderLeftActions" runat="server"/>
<asp:ContentPlaceHolder id="PlaceHolderPageDescription" runat="server" />